### PR TITLE
Corrected first link in 'Related Work' in Dataset Distillation page

### DIFF
--- a/dataset_distillation/index.html
+++ b/dataset_distillation/index.html
@@ -219,7 +219,7 @@ Check out our latest CVPR 2022 work:
 
 <ul id='relatedwork'>
 <li>
- Geoffrey Hinton, Oriol Vinyals, and Jeff Dean. <a href="https://arxiv.org/abs/1406.2661"><strong>"Distilling the Knowledge in a Neural Network"</strong></a>, in NIPS Deep Learning Workshop 2014.
+ Geoffrey Hinton, Oriol Vinyals, and Jeff Dean. <a href="https://arxiv.org/abs/1503.02531"><strong>"Distilling the Knowledge in a Neural Network"</strong></a>, in NIPS Deep Learning Workshop 2014.
 </li>
 <li> Dougal Maclaurin, David Duvenaud, and Ryan Adams. <a href="https://arxiv.org/abs/1502.03492"><strong>"Gradient-based hyperparameter optimization through reversible learning"</strong></a>, in ICML 2015.
 </li>


### PR DESCRIPTION
The link for 'Distilling the Knowledge in a Neural Network' (Geoffrey Hinton, Oriol Vinyals, Jeff Dean - 2015) actually linked to the famous GANs paper (Ian Goodfellow et al. - 2014)
Corrected the link to the right one